### PR TITLE
Fix encoding of fgoTeamup.ini

### DIFF
--- a/FGO-py/fgoIniParser.py
+++ b/FGO-py/fgoIniParser.py
@@ -1,2 +1,2 @@
 from configparser import ConfigParser
-IniParser=type('IniParser',(ConfigParser,),{'__init__':lambda self,file:(ConfigParser.__init__(self),self.read(file))[0],'optionxform':lambda self,optionstr:optionstr})
+IniParser=type('IniParser',(ConfigParser,),{'__init__':lambda self,file:(ConfigParser.__init__(self),self.read(file,'utf-8'))[0],'optionxform':lambda self,optionstr:optionstr})


### PR DESCRIPTION
The default encoding of Chinese on python(Win64) is GBK. So It may be unable to launch with Chinese in fgoTeamup.ini.
(btw SORRY for the wrong PR again)