### PR TITLE
修复了使用`/bs4`对蓝叠4进行连接的一个bug

### DIFF
--- a/FGO-py/fgoDevice.py
+++ b/FGO-py/fgoDevice.py
@@ -21,7 +21,7 @@ def gw(*args):
 @regHelper
 def bs4(*args):
     import winreg
-    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return'127.0.0.1:'+winreg.QueryValueEx(key,"BstAdbPort")[0]
+    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return'127.0.0.1:'+str(winreg.QueryValueEx(key,"BstAdbPort")[0])
 @regHelper
 def bs5(*args):
     import os,re,winreg

--- a/FGO-py/fgoDevice.py
+++ b/FGO-py/fgoDevice.py
@@ -21,7 +21,7 @@ def gw(*args):
 @regHelper
 def bs4(*args):
     import winreg
-    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return'127.0.0.1:'+str(winreg.QueryValueEx(key,"BstAdbPort")[0])
+    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return f'127.0.0.1:{winreg.QueryValueEx(key,"BstAdbPort")[0]}'
 @regHelper
 def bs5(*args):
     import os,re,winreg


### PR DESCRIPTION
## Bug描述
在使用`/bs4`进行连接时，发现无法连接，看控制台报的错误为
```
[2023-01-03 20:15:12,689][ERROR]<fgo.Device> can only concatenate str (not "int") to str
Traceback (most recent call last):
  File "F:\Git\FGO-py\FGO-py\FGO-py\fgoDevice.py", line 14, in convert
    try:return(lambda args:helpers[args[0][1:]](*args[1:]))(text.split('_'))
  File "F:\Git\FGO-py\FGO-py\FGO-py\fgoDevice.py", line 14, in <lambda>
    try:return(lambda args:helpers[args[0][1:]](*args[1:]))(text.split('_'))
  File "F:\Git\FGO-py\FGO-py\FGO-py\fgoDevice.py", line 24, in bs4
    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return'127.0.0.1:'+winreg.QueryValueEx(key,"BstAdbPort")[0]
TypeError: can only concatenate str (not "int") to str
```
## 解决方案
在`fgoDevice.py`的第24行，进行变量类型转换
```python
    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return'127.0.0.1:'+str(winreg.QueryValueEx(key,"BstAdbPort")[0])
```