### PR TITLE
适配更多蓝叠版本

### DIFF
--- a/FGO-py/fgoDevice.py
+++ b/FGO-py/fgoDevice.py
@@ -24,9 +24,10 @@ def bs4(*args):
     with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return f'127.0.0.1:{winreg.QueryValueEx(key,"BstAdbPort")[0]}'
 @regHelper
 def bs5(*args):
+    instance_name=args[0]if args else'Nougat64'
     import os,re,winreg
     with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,r'SOFTWARE\BlueStacks_nxt')as key:dir=winreg.QueryValueEx(key,'UserDefinedDir')[0]
-    with open(os.path.join(dir,'bluestacks.conf'),encoding='utf-8')as f:return'127.0.0.1:'+re.search(rf'bst\.instance\.Nougat64{f"_{args[0]}"if args else""}\.status\.adb_port="(\d*)"',f.read()).group(1)
+    with open(os.path.join(dir,'bluestacks.conf'),encoding='utf-8')as f:return'127.0.0.1:'+re.search(rf'bst\.instance\.{instance_name}\.status\.adb_port="(\d*)"',f.read()).group(1)
 
 class Device:
     def __init__(self,name=None):

--- a/FGO-py/fgoDevice.py
+++ b/FGO-py/fgoDevice.py
@@ -24,7 +24,7 @@ def bs4(*args):
     with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,rf'SOFTWARE\BlueStacks_bgp64_hyperv\Guests\Android{f"_{args[0]}"if args else""}\Config')as key:return f'127.0.0.1:{winreg.QueryValueEx(key,"BstAdbPort")[0]}'
 @regHelper
 def bs5(*args):
-    instance_name=args[0]if args else'Nougat64'
+    instance_name = args[0].replace('_', '', 1) if args else 'Nougat64'
     import os,re,winreg
     with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,r'SOFTWARE\BlueStacks_nxt')as key:dir=winreg.QueryValueEx(key,'UserDefinedDir')[0]
     with open(os.path.join(dir,'bluestacks.conf'),encoding='utf-8')as f:return'127.0.0.1:'+re.search(rf'bst\.instance\.{instance_name}\.status\.adb_port="(\d*)"',f.read()).group(1)


### PR DESCRIPTION
使用/bs5_Pie64_1来启动Pie64的第二个模拟器