### PR TITLE
fix: docker build bug

### DIFF
--- a/deploy/Docker/Dockerfile
+++ b/deploy/Docker/Dockerfile
@@ -12,7 +12,10 @@ WORKDIR /FGO-py
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
  && echo 'Asia/Shanghai' > /etc/timezone \
  && pip install airtest tqdm flask pponnxcr pulp\
+ && pip install --upgrade opencv-python==4.7.0.72 \
  && pip uninstall -y opencv-contrib-python \
  && pip install opencv-contrib-python-headless \
+ && apt update \
+ && apt install libgl1-mesa-glx libglib2.0-0 -y \
  && rm -r ~/.cache/pip
 CMD ["python", "-X", "utf8", "fgo.py", "cli"]


### PR DESCRIPTION
解决docker容器启动报错AttributeError: module 'cv2.dnn' has no attribute 'DictValue'，如下图所示：

<img width="1105" height="591" alt="6c789eb3203149bd77dea80daad3bb43" src="https://github.com/user-attachments/assets/48676e80-b79b-4b96-a7e5-d2f5ccfc1ffc" />

修复后，可正常启动容器：

<img width="1766" height="198" alt="image" src="https://github.com/user-attachments/assets/8e68a529-d168-49fd-91da-85f1832b76e2" />
