### PR TITLE
feat: ALAS结合的readme教程调整 & 限制airtest版本

### DIFF
--- a/deploy/AzurLaneAutoScript/readme.md
+++ b/deploy/AzurLaneAutoScript/readme.md
@@ -13,6 +13,35 @@ plain - 基本的在linux机器上部署的Alas和FGO-py
 portable - 多数用户使用的portable installer安装的Alas和FGO-py  
 docker - 在docker中运行FGO-py,而Alas在主机中  
 
+## Windows下本机使用：(推荐使用docker方式！)
+
+### portable方式：不推荐
+portable.launch.bat 改名为 launch.bat,放到AzurLaneAutoScript目录下。
+
+执行时报错：from .onnxruntime_pybind11_state import *: ImportError: DLL load failed while importing onnxruntime_pybind11_state: 动态链接库(DLL)初始化例程失败。  
+解决：主要是因为onnxruntime版本问题，我本地是onnxruntime 1.22.1，改为1.17即可。  
+pip uninstall onnxruntime   
+pip install onnxruntime==1.17  
+
+报错：SyntaxError: invalid syntax  
+原因：ALAS用到python是3.7.6(AzurLaneAutoScript\toolkit)，不支持最新的match语法。故暂时不建议使用此方式。  
+
+### docker方式：推荐
+(1)将docker.launch改为launch.bat, docker.half改名为half.bat 放到AzurLaneAutoScript目录下。  
+(2)修改launch.bat文件：  
+docker run -v F:/develop/gameScriptTool/FGO-py-win/FGO-py/FGO-py:/FGO-py --name fgo-py -e NO_COLOR=1 -i --rm hgjazhgj/fgo-py   
+主要是把-v 的宿主机路径改为你自己本地路径即可, 然后删掉#!/bin/bash，另外windows需要在系统-开发者选项中启用sudo才能使用sudo，否则删除sudo即可。   
+(3)构建hgjazhgj/fgo-py镜像(cd到 deploy/Docker目录下)：  
+docker build -t hgjazhgj/fgo-py .  
+
+启动alas后，填写模拟器 Serial： 
+即配置模拟器的 ip 和 端口： 192.168.31.128:5557  
+PS： ip查询 执行ipconfig即可。  
+模拟器端口 执行adb devices 。 
+emulator-5556，我这里端口是+1后的5557，具体可执行此命令查看：netstat -ano | findstr :555  
+
+
+## linux下使用
 本人将Alas和FGO-py分别部署在两个docker容器中,那么,以下是本人实际使用的launch与halt:  
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-airtest
+airtest==1.3.4
 PySide6
 tqdm
 Flask


### PR DESCRIPTION
1.deploy/AzurLaneAutoScript/readme.md 内容调整，个人感觉里面有些地方写的不够详细。
比如：将docker.launch改为launch.bat, docker.half改名为half.bat  并且需要放到AzurLaneAutoScript目录下。
这个是我碰到No provider specified, skip sending报错后，翻找issue才找到相关细节，readme里没体现。

另外portable方式，貌似无法与ALAS结合，因为ALAS使用的时python3.7.6，不支持match语法，调用不了

2.airtest版本限制到1.3.4
原因是：我这边连接到雷电模拟器时报错，ADBTOUCH does not support server_proc method
与此issue一致
#163 

